### PR TITLE
Added `feed` and `data` to the filter list

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -138,7 +138,7 @@
 				'#(<[^>]+[\x00-\x20\"\'\/])(on|xmlns)[^>]*>?#iUu',
 
 				// Match javascript:, livescript:, vbscript: and mocha: protocols
-				'!((java|live|vb)script|mocha):(\w)*!iUu',
+				'!((java|live|vb)script|mocha|feed|data):(\w)*!iUu',
 				'#-moz-binding[\x00-\x20]*:#u',
 
 				// Match style attributes


### PR DESCRIPTION
There are two known types of XSS attacks that the xssfilter extension does not account for:

`data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==`

`feed:data:text/html,%3csvg%20onload=alert%281%29%3e` _(Firefox only)_

These can be easily prevented by adding the `data` and `feed` protocol to the exclusion list.
